### PR TITLE
Update terraform.tfvars.ci to be consistent with documentation

### DIFF
--- a/terraform.tfvars.ci
+++ b/terraform.tfvars.ci
@@ -11,5 +11,5 @@ extra_tags = {
 }
 
 public_network_enabled          = false
-managed_virtual_network_enabled = false
+managed_virtual_network_enabled = true
 logs_retention_days             = 90


### PR DESCRIPTION
We noticed that https://registry.terraform.io/modules/claranet/data-factory/azurerm/latest shows the attribute `managed_virtual_network_enabled` is not required, and defaults to `true` but the code itself had set the default value to `false`.

Fixing this to make the implementation consistent with the documentation.

Fixes #1  .

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Changes proposed in this pull request

Changes the default value for `managed_virtual_network_enabled` from `false` to `true` so that it matches the documentation.

@claranet/fr-azure-reviewers
